### PR TITLE
Partial fix for bug #11

### DIFF
--- a/sleep_inhibit.py
+++ b/sleep_inhibit.py
@@ -17,20 +17,23 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+if 'DISPLAY' not in os.environ or not os.environ['DISPLAY']:
+    exit('This program must be run from a graphical (X) session, and DISPLAY must be properly set.')
+
 import gi
 gi.require_version('Gtk', '3.0')
 gi.require_version('AppIndicator3', '0.1')
 gi.require_version('GdkPixbuf', '2.0')
-import os
 
 from sleepinhibit.settings import get_settings
 from sleepinhibit.startup import main
 
 config = get_settings()
 config.start_file = os.path.realpath(__file__)
-config.program_dir = '{}/sleepinhibit'.format(os.path.dirname(os.path.realpath(__file__)))
+config.program_dir = '{}/sleepinhibit'.format(os.path.dirname(config.start_file))
 config.desktop_filename = '{}/.config/autostart/sleep_inhibit.desktop'.format(os.environ['HOME'])
-config.version = '1.0.0~beta'
+config.version = '1.0.0~beta2'
 config.inhibitor_interval = 3 # Value is in minutes
 
 if __name__ == '__main__':

--- a/sleep_inhibit.py
+++ b/sleep_inhibit.py
@@ -19,7 +19,10 @@
 
 import os
 if 'DISPLAY' not in os.environ or not os.environ['DISPLAY']:
-    exit('This program must be run from a graphical (X) session, and DISPLAY must be properly set.')
+    if __name__ == '__main__':
+        exit('This program must be run from a graphical (X) session, and DISPLAY must be properly set.')
+    else:
+        print("Many features require a graphical environment, which you don't seem to have. When importing this module, it's your responsibility to ensure that you don't call any such code.")
 
 import gi
 gi.require_version('Gtk', '3.0')

--- a/sleepinhibit/startup.py
+++ b/sleepinhibit/startup.py
@@ -35,6 +35,10 @@ def dependencies_are_satisfied():
         subprocess.call('xdotool', stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     except FileNotFoundError:
         return False
+    except subprocess.CalledProcessError as e:
+        print('Error: xprintidle said: "{}"'.format(e.stderr))
+        #print(repr(e))
+        return False
     return True
 
 def parse_args():
@@ -49,7 +53,7 @@ def parse_args():
             return n
         else:
             raise TypeError('Invalid Percentage!')
-    
+
     parser = ArgumentParser(description='''Indicator to prevent
         computer from sleeping. It depends on the commands xprintidle and
         xdotool being properly installed on your system. If they aren't
@@ -82,8 +86,6 @@ def main():
     config = settings.get_settings()
     if not dependencies_are_satisfied():
         return 'This program depends on xprintidle and xdotool being installed.'
-    #if args.battery and not battery.acpi_available():
-    #    return '--battery is only available if you have the acpi command on your system.'
     config.acpi_available = battery.acpi_available()
     if args.delete:
         config = settings.get_settings()

--- a/sleepinhibit/util.py
+++ b/sleepinhibit/util.py
@@ -26,7 +26,11 @@ from gi.repository import Gio, GdkPixbuf
 from sleepinhibit.settings import get_settings
 
 def cmd_output(*args, **kwargs):
-    '''Wrap subprocess.check_output to avoid having to do conversions, strip, etc.'''
+    '''Wrap subprocess.check_output to avoid having to do conversions, strip, etc.
+
+    If the command doesn't exist, raises `FileNotFoundError`. If the command exits
+    with a nonzero status, raises `subprocess.CalledProcessError` with the returned
+    result available on the exception object as `output`.'''
     return subprocess.check_output(*args, **kwargs).decode('utf-8').strip()
 
 def app_icon(which, return_pixbuf=True, theme=None):


### PR DESCRIPTION
Starting Sleep Inhibitor now prints a useful error message when attempting to start without having an X session (as determined by whether or not `$DISPLAY` is set).
